### PR TITLE
Limit file types on frontend and backend

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -48,7 +48,7 @@
       <span id="center-text">
         <p>drop shit or <span id="browse">click this</span></p>
         <p id="error">⚠</p>
-        <input type="file" id="file-input" style="display: none" />
+        <input type="file" id="file-input" accept="image/*,video/*" style="display: none" />
       </span>
       <img src="static/shuffle.svg" alt="spinner" id="spinner" />
     </div>


### PR DESCRIPTION
We just limit the file types in the file selector as a user convenience while browsing. They can still browse for All Files if needed, which is why we don't do any validation on the URL or drag 'n drop.

The backend handles this now.