### PR TITLE
Switch "port" to "bind"

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,22 +10,22 @@ import (
 )
 
 const usage = `Usage:
+  -b, --bind           address:port to run the server on (default: 0.0.0.0:3000)
   -c, --config         Path to a configuration file (default: config.toml)
-  -p, --port           Port to run the server on (default: 3000)
   -s, --serve-path     Path to serve images from (default: /i/)
   -u, --upload-path    Path to store uploaded images (default: ./uploads/)`
 
 func GenerateConfig() Config {
 	// Parse the command-line flags and load the config
+	var bindOpt string
 	var configFile string
-	var portOpt string
 	var servePathOpt string
 	var uploadPathOpt string
 
+	flag.StringVar(&bindOpt, "b", "0.0.0.0:3000", "address:port to run the server on")
+	flag.StringVar(&bindOpt, "bind", "0.0.0.0:3000", "address:port to run the server on")
 	flag.StringVar(&configFile, "c", "config.toml", "Path to the configuration file")
 	flag.StringVar(&configFile, "config", "config.toml", "Path to the configuration file")
-	flag.StringVar(&portOpt, "p", "3000", "Port to run the server on")
-	flag.StringVar(&portOpt, "port", "3000", "Port to run the server on")
 	flag.StringVar(&servePathOpt, "s", "", "Path to serve images from")
 	flag.StringVar(&servePathOpt, "serve-path", "", "Path to serve images from")
 	flag.StringVar(&uploadPathOpt, "u", "", "Path to store uploaded images")
@@ -41,7 +41,7 @@ func GenerateConfig() Config {
 
 	// Load the config file if it exists otherwise use default values
 	if _, err := os.Stat(configFile); err != nil {
-		config.Port = "3000"
+		config.Bind = "0.0.0.0:3000"
 		config.ServePath = "/i/"
 		config.UploadPath = "./uploads/"
 	} else {
@@ -50,7 +50,7 @@ func GenerateConfig() Config {
 
 	// Override the config values with the command-line flags
 	options := map[*string]*string{
-		&portOpt:       &config.Port,
+		&bindOpt:       &config.Bind,
 		&servePathOpt:  &config.ServePath,
 		&uploadPathOpt: &config.UploadPath,
 	}

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,4 +1,4 @@
-port = "3000"
+bind = "0.0.0.0:3000"
 serve_path = "/i/"
 upload_path = "./uploads/"
 

--- a/load_config_test.go
+++ b/load_config_test.go
@@ -14,7 +14,7 @@ func TestLoadConfig(t *testing.T) {
 	defer os.Remove(tempFile.Name())
 
 	configContent := `
-port = ":666"
+bind = "localhost:666"
 serve_path = "/p/"
 upload_path = "./grapes/"
 `
@@ -25,8 +25,8 @@ upload_path = "./grapes/"
 	config := loadConfig(tempFile.Name())
 
 	// Check if the loaded config matches the expected config
-	expectedPort := ":666"
-	if config.Port != expectedPort {
-		t.Errorf("Expected port to be %s, but got %s", expectedPort, config.Port)
+	expectedBind := "localhost:666"
+	if config.Bind != expectedBind {
+		t.Errorf("Expected bind to be %s, but got %s", expectedBind, config.Bind)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -13,13 +13,12 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"text/template"
 	"time"
 )
 
 type Config struct {
-	Port       string `toml:"port"`
+	Bind       string `toml:"bind"`
 	ServePath  string `toml:"serve_path"`
 	UploadPath string `toml:"upload_path"`
 }
@@ -81,12 +80,11 @@ func main() {
 		io.Copy(w, file)
 	})
 
-	config.Port = strings.TrimPrefix(config.Port, ":")
-
-	fmt.Printf("Server is running on port %s\n"+
+	fmt.Printf("Server is running on http://%s\n"+
 		"Serving images at %s\n"+
 		"Upload path is %s\n",
-		config.Port, config.ServePath, config.UploadPath)
+
+		config.Bind, config.ServePath, config.UploadPath)
 
 	if *debug {
 		for hash, filename := range hashes {
@@ -94,7 +92,7 @@ func main() {
 		}
 	}
 
-	log.Fatal(http.ListenAndServe(":"+config.Port, nil))
+	log.Fatal(http.ListenAndServe(config.Bind, nil))
 }
 
 func newMimeTypeHandler() *MimeTypeHandler {


### PR DESCRIPTION
Default behavior for http.ListenAndServe is to bind 0.0.0.0. Hosts may have multiple interfaces or may not want to serve externally at all and only bind localhost.