### PR TITLE
Fix image urls without file extensions

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,14 +155,35 @@ func urlUploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	parsedUrl, err := url.Parse(urlString)
+	filename, err := generateFilename(urlString, resp)
 	if err != nil {
 		return
 	}
 
-	filename := path.Base(parsedUrl.Path)
-
 	writeFileAndReturnURL(w, r, resp.Body, filename)
+}
+
+func generateFilename(urlString string, resp *http.Response) (string, error) {
+	parsedUrl, err := url.Parse(urlString)
+	if err != nil {
+		return "", err
+	}
+
+	filename := path.Base(parsedUrl.Path)
+	if !strings.Contains(filename, ".") {
+		contentType := resp.Header.Get("Content-Type")
+		ext := ""
+		switch contentType {
+		case "image/jpeg":
+			ext = ".jpg"
+		case "image/png":
+			ext = ".png"
+		case "image/gif":
+			ext = ".gif"
+		}
+		filename = filename + ext
+	}
+	return filename, nil
 }
 
 func writeFileAndReturnURL(w http.ResponseWriter, r *http.Request, file io.Reader, filename string) error {

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,13 +32,22 @@
         border-color: #007bff;
       }
 
-      #spinner { display: none; }
+      #spinner {
+        display: none;
+      }
+
+      #error {
+        color: #bd0000;
+        font-weight: 500;
+        visibility: hidden;
+      }
     </style>
   </head>
   <body>
     <div id="drop-area" class="full-page-drop-area">
       <span id="center-text">
         <p>drop shit or <span id="browse">click this</span></p>
+        <p id="error">⚠</p>
         <input type="file" id="file-input" style="display: none" />
       </span>
       <img src="static/shuffle.svg" alt="spinner" id="spinner" />

--- a/templates/static/script.js
+++ b/templates/static/script.js
@@ -44,7 +44,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // handle image
     const imageItem = Array.from(clipboardData.items).find((item) =>
-      item.type.includes("image"),
+      item.type.includes("image")
     );
     if (imageItem) {
       handleFileUpload(imageItem.getAsFile());
@@ -57,12 +57,21 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  function handleError(errorText) {
+    const error = document.getElementById("error");
+    error.textContent = `⚠ ${errorText}`;
+    error.style.visibility = "visible";
+
+    console.error("something goofed:", errorText);
+  }
+
   async function handleResponse(response) {
     if (response.ok) {
       const result = await response.json();
       window.location.href = result.url;
     } else {
-      console.error("something goofed:", response.status);
+      const errorText = await response.text();
+      handleError(errorText.toLowerCase());
     }
   }
 

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,3 +5,4 @@ COPY tests/scripts/* /tmp/
 COPY tests/images/* /tmp/
 COPY tests/images/* /usr/share/nginx/html/
 COPY tests/images/test.jpg /usr/share/nginx/html/test.test.jpg
+COPY tests/images/test.jpg /usr/share/nginx/html/extlessjpg

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,5 +4,5 @@ COPY tests/scripts/* /tmp/
 
 COPY tests/images/* /tmp/
 COPY tests/images/* /usr/share/nginx/html/
-COPY tests/images/test.jpg /usr/share/nginx/html/test.test.jpg
+COPY tests/images/test.jpg /usr/share/nginx/html/jpg.not.zip
 COPY tests/images/test.jpg /usr/share/nginx/html/extlessjpg

--- a/tests/scripts/test.sh
+++ b/tests/scripts/test.sh
@@ -19,6 +19,30 @@ else
   ERRORS=$((ERRORS+1))
 fi
 
+# --== Extless Url Upload Test ==--
+
+printf "Testing extless URL upload: "
+
+URLPAYLOAD='{"url":"http://nginx/extlessjpg"}'
+
+IMAGELOC=$(
+  curl -s \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d "${URLPAYLOAD}" grombley:3000/url \
+      | grep -oP '(?<="url":")[^"]+'
+)
+
+curl --fail-with-body -s -I "$IMAGELOC" | tee > /tmp/extless
+
+if grep -q "$CONTENT_TYPE" /tmp/extless; then
+  printf "✅ - Extless URL upload success\n\n"
+else
+  printf "❌ - Extless URL upload failed\n\n"
+  cat /tmp/extless
+  ERRORS=$((ERRORS+1))
+fi
+
 # --== URL Upload Test ==--
 
 printf "Testing URL upload: "

--- a/tests/scripts/test.sh
+++ b/tests/scripts/test.sh
@@ -47,7 +47,7 @@ fi
 
 printf "Testing URL upload: "
 
-URLPAYLOAD='{"url":"http://nginx/test.test.jpg"}'
+URLPAYLOAD='{"url":"http://nginx/jpg.not.zip"}'
 
 IMAGELOC=$(
   curl -s \


### PR DESCRIPTION
There is no obvious filename in a url like: https://pbs.twimg.com/media/GTDnuQ2XAAAPjC2?format=jpg&name=large

We can derive an ext from the response's content type

fixes #42 