### PR TITLE
Convert heic to jpg

### DIFF
--- a/converters.go
+++ b/converters.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"image/jpeg"
+	"io"
+	"log"
+
+	"github.com/jdeng/goheif"
+)
+
+func isHEIC(header []byte) bool {
+	// heic files start with a 'ftyp' box after a 4-byte size.
+	// [4 bytes size][4 bytes 'ftyp'][brand identifier]
+	// https://mp4ra.org/registered-types/brands
+	signatures := [][]byte{
+		[]byte("ftypheic"),
+	}
+
+	for _, sig := range signatures {
+		if len(header) >= len(sig)+4 {
+			if bytes.Contains(header[4:], sig[4:]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func convertHEICToJPEG(src io.Reader) (io.Reader, error) {
+	img, err := goheif.Decode(src)
+	if err != nil {
+		log.Printf("HEIC decoding failed: %v", err)
+		return nil, err
+	}
+	buf := new(bytes.Buffer)
+	if err := jpeg.Encode(buf, img, &jpeg.Options{Quality: 90}); err != nil {
+		log.Printf("JPEG encoding failed: %v", err)
+		return nil, err
+	}
+	return buf, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module github.com/rbuysse/image-uploader
 
-go 1.22
+go 1.22.3
+
+toolchain go1.23.3
 
 require github.com/BurntSushi/toml v1.3.2
+
+require github.com/jdeng/goheif v0.0.0-20241115163857-e2bbb197c985 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/jdeng/goheif v0.0.0-20241115163857-e2bbb197c985 h1:PpWPfNoLsnQxhnu4Hp4WQaRK53i0Xikp9347gS0ThAg=
+github.com/jdeng/goheif v0.0.0-20241115163857-e2bbb197c985/go.mod h1:whEdtAJfm8ia675sbmIATUVAT/P9gnb7zHpR3hzqst0=


### PR DESCRIPTION
This PR adds:

- https://github.com/jdeng/goheif
- A converters.go file to keep this less messy in main.go
- If content type is an application/octet-stream we further check if it's an heic, setting its extension to .heic
- In the write file function, if heic, convert to jpg

I was testing these: https://github.com/tigranbs/test-heic-images