### PR TITLE
Add optional redirect to a different url after image upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,13 @@ or command-line flags. An example config file is provided at
 Command-line flags override values in the config file. If no config file is
 found, defaults are used.
 
-| Option         | TOML Key     | CLI Flag(s)                | Default Value      | Description                           |
-|----------------|--------------|----------------------------|--------------------|---------------------------------------|
-| Config file    | —            | `-c`, `--config`           | `config.toml`      | Path to the configuration file        |
-| Bind address   | `bind`       | `-b`, `--bind`             | `0.0.0.0:3000`     | Address and port to run the server on |
-| Debug mode     | `debug`      | `--debug`                  | `false`            | Enable debug mode                     |
-| Serve path     | `serve_path` | `-s`, `--serve-path`       | `/i/`              | Path to serve images from             |
-| Upload path    | `upload_path`| `-u`, `--upload-path`      | `./uploads/`       | Path to store uploaded images         |
+| Option         | TOML Key       | CLI Flag(s)                | Default Value      | Description                           |
+|----------------|----------------|----------------------------|--------------------|---------------------------------------|
+| Config file    | —              | `-c`, `--config`           | `config.toml`      | Path to the configuration file        |
+| Bind address   | `bind`         | `-b`, `--bind`             | `0.0.0.0:3000`     | Address and port to run the server on |
+| Debug mode     | `debug`        | `--debug`                  | `false`            | Enable debug mode                     |
+| Redirect URL   | `redirect_url` | `-r`, `--redirect-url`     | _(none)_           | Base URL for uploaded file redirects  |
+| Serve path     | `serve_path`   | `-s`, `--serve-path`       | `/i/`              | Path to serve images from             |
+| Upload path    | `upload_path`  | `-u`, `--upload-path`      | `./uploads/`       | Path to store uploaded images         |
+
+**Note:** When `redirect_url` is not set, the request host is used. URLs without a scheme automatically default to `https://`.

--- a/config.go
+++ b/config.go
@@ -14,15 +14,17 @@ import (
 const usage = `Usage:
   -b, --bind           address:port to run the server on (default: 0.0.0.0:3000)
   -c, --config         Path to a configuration file (default: config.toml)
+  -r, --redirect-url   Base URL for redirects after upload (default: none)
   -s, --serve-path     Path to serve images from (default: /i/)
   -u, --upload-path    Path to store uploaded images (default: ./uploads/)`
 
 // Default config
 func defaultConfig() Config {
 	return Config{
-		Bind:       "0.0.0.0:3000",
-		ServePath:  "/i/",
-		UploadPath: "./uploads/",
+		Bind:        "0.0.0.0:3000",
+		RedirectURL: "",
+		ServePath:   "/i/",
+		UploadPath:  "./uploads/",
 	}
 }
 
@@ -31,6 +33,7 @@ func GenerateConfig() Config {
 	var configFile string
 	var configFileSet bool
 	var debugOpt bool
+	var redirectURLOpt string
 	var servePathOpt string
 	var uploadPathOpt string
 
@@ -39,6 +42,8 @@ func GenerateConfig() Config {
 	flag.StringVar(&configFile, "c", "", "Path to the configuration file")
 	flag.StringVar(&configFile, "config", "", "Path to the configuration file")
 	flag.BoolVar(&debugOpt, "debug", false, "enable debug mode")
+	flag.StringVar(&redirectURLOpt, "r", "", "Base URL for redirects after upload")
+	flag.StringVar(&redirectURLOpt, "redirect-url", "", "Base URL for redirects after upload")
 	flag.StringVar(&servePathOpt, "s", "", "Path to serve images from")
 	flag.StringVar(&servePathOpt, "serve-path", "", "Path to serve images from")
 	flag.StringVar(&uploadPathOpt, "u", "", "Path to store uploaded images")
@@ -79,9 +84,10 @@ func GenerateConfig() Config {
 
 	// Override the config values with the command-line flags
 	options := map[*string]*string{
-		&bindOpt:       &config.Bind,
-		&servePathOpt:  &config.ServePath,
-		&uploadPathOpt: &config.UploadPath,
+		&bindOpt:        &config.Bind,
+		&redirectURLOpt: &config.RedirectURL,
+		&servePathOpt:   &config.ServePath,
+		&uploadPathOpt:  &config.UploadPath,
 	}
 
 	for option, configField := range options {
@@ -116,10 +122,11 @@ func loadConfig(configFile string) Config {
 
 	// Temporary struct to decode TOML file
 	var tempConfig struct {
-		Bind       string `toml:"bind"`
-		Debug      bool   `toml:"debug"`
-		ServePath  string `toml:"serve_path"`
-		UploadPath string `toml:"upload_path"`
+		Bind        string `toml:"bind"`
+		Debug       bool   `toml:"debug"`
+		RedirectURL string `toml:"redirect_url"`
+		ServePath   string `toml:"serve_path"`
+		UploadPath  string `toml:"upload_path"`
 	}
 
 	if _, err := toml.DecodeFile(configFile, &tempConfig); err != nil {
@@ -130,14 +137,17 @@ func loadConfig(configFile string) Config {
 	if tempConfig.Bind != "" {
 		config.Bind = tempConfig.Bind
 	}
+	if tempConfig.Debug {
+		config.Debug = true
+	}
+	if tempConfig.RedirectURL != "" {
+		config.RedirectURL = tempConfig.RedirectURL
+	}
 	if tempConfig.ServePath != "" {
 		config.ServePath = tempConfig.ServePath
 	}
 	if tempConfig.UploadPath != "" {
 		config.UploadPath = tempConfig.UploadPath
-	}
-	if tempConfig.Debug {
-		config.Debug = true
 	}
 
 	return config

--- a/config.toml.example
+++ b/config.toml.example
@@ -2,3 +2,7 @@ bind = "0.0.0.0:3000"
 debug = false
 serve_path = "/i/"
 upload_path = "./uploads/"
+
+# Optional: Base URL for redirects after upload (e.g., "https://example.com")
+# If not set, will use the request host
+# redirect_url = ""

--- a/handler.go
+++ b/handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 )
 
@@ -99,11 +100,22 @@ func urlUploadHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func constructFileURL(r *http.Request, filename string) string {
-	scheme := "http://"
-	if r.TLS != nil {
-		scheme = "https://"
+	// Use configured redirect URL if set, otherwise use request host
+	baseURL := config.RedirectURL
+	if baseURL == "" {
+		scheme := "http://"
+		if r.TLS != nil {
+			scheme = "https://"
+		}
+		baseURL = fmt.Sprintf("%s%s", scheme, r.Host)
+	} else {
+		// Ensure redirect URL has a scheme
+		if !strings.HasPrefix(baseURL, "http://") && !strings.HasPrefix(baseURL, "https://") {
+			// Default to https if no scheme provided
+			baseURL = "https://" + baseURL
+		}
 	}
-	return fmt.Sprintf("%s%s%s%s", scheme, r.Host, config.ServePath, filename)
+	return fmt.Sprintf("%s%s%s", baseURL, config.ServePath, filename)
 }
 
 func respondWithFileURL(w http.ResponseWriter, r *http.Request, url string) error {

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+)
+
+func TestConstructFileURL(t *testing.T) {
+	// Save original config and restore after tests
+	originalConfig := config
+	defer func() { config = originalConfig }()
+
+	t.Run("uses request host when redirect_url is empty", func(t *testing.T) {
+		config = Config{
+			ServePath:   "/i/",
+			RedirectURL: "",
+		}
+
+		req := &http.Request{
+			Host: "example.com:3000",
+			TLS:  nil,
+		}
+
+		result := constructFileURL(req, "test.jpg")
+		expected := "http://example.com:3000/i/test.jpg"
+
+		if result != expected {
+			t.Errorf("Expected %s, but got %s", expected, result)
+		}
+	})
+
+	t.Run("uses https when request has TLS", func(t *testing.T) {
+		config = Config{
+			ServePath:   "/i/",
+			RedirectURL: "",
+		}
+
+		req := &http.Request{
+			Host: "example.com",
+			TLS:  &tls.ConnectionState{},
+		}
+
+		result := constructFileURL(req, "test.jpg")
+		expected := "https://example.com/i/test.jpg"
+
+		if result != expected {
+			t.Errorf("Expected %s, but got %s", expected, result)
+		}
+	})
+
+	t.Run("uses redirect_url when configured", func(t *testing.T) {
+		config = Config{
+			ServePath:   "/i/",
+			RedirectURL: "https://cdn.example.com",
+		}
+
+		req := &http.Request{
+			Host: "upload.example.com:3000",
+			TLS:  nil,
+		}
+
+		result := constructFileURL(req, "test.jpg")
+		expected := "https://cdn.example.com/i/test.jpg"
+
+		if result != expected {
+			t.Errorf("Expected %s, but got %s", expected, result)
+		}
+	})
+
+	t.Run("redirect_url ignores request TLS state", func(t *testing.T) {
+		config = Config{
+			ServePath:   "/i/",
+			RedirectURL: "http://cdn.example.com",
+		}
+
+		req := &http.Request{
+			Host: "upload.example.com",
+			TLS:  &tls.ConnectionState{}, // Has TLS but redirect_url should be used as-is
+		}
+
+		result := constructFileURL(req, "test.jpg")
+		expected := "http://cdn.example.com/i/test.jpg"
+
+		if result != expected {
+			t.Errorf("Expected %s, but got %s", expected, result)
+		}
+	})
+
+	t.Run("redirect_url with different serve_path", func(t *testing.T) {
+		config = Config{
+			ServePath:   "/media/",
+			RedirectURL: "https://cdn.example.com",
+		}
+
+		req := &http.Request{
+			Host: "example.com",
+			TLS:  nil,
+		}
+
+		result := constructFileURL(req, "photo.png")
+		expected := "https://cdn.example.com/media/photo.png"
+
+		if result != expected {
+			t.Errorf("Expected %s, but got %s", expected, result)
+		}
+	})
+
+	t.Run("redirect_url with trailing slash", func(t *testing.T) {
+		config = Config{
+			ServePath:   "/i/",
+			RedirectURL: "https://cdn.example.com/",
+		}
+
+		req := &http.Request{
+			Host: "example.com",
+			TLS:  nil,
+		}
+
+		result := constructFileURL(req, "image.gif")
+		expected := "https://cdn.example.com//i/image.gif"
+
+		if result != expected {
+			t.Errorf("Expected %s, but got %s", expected, result)
+		}
+	})
+
+	t.Run("redirect_url without scheme", func(t *testing.T) {
+		config = Config{
+			ServePath:   "/i/",
+			RedirectURL: "cdn.example.com",
+		}
+
+		req := &http.Request{
+			Host: "example.com",
+			TLS:  nil,
+		}
+
+		result := constructFileURL(req, "test.jpg")
+		expected := "https://cdn.example.com/i/test.jpg"
+
+		if result != expected {
+			t.Errorf("Expected %s, but got %s", expected, result)
+		}
+	})
+}

--- a/load_config_test.go
+++ b/load_config_test.go
@@ -37,6 +37,10 @@ func TestConfig(t *testing.T) {
 			t.Errorf("Expected default upload_path to be ./uploads/, but got %s", config.UploadPath)
 		}
 
+		if config.RedirectURL != "" {
+			t.Errorf("Expected default redirect_url to be empty, but got %s", config.RedirectURL)
+		}
+
 		if config.Debug {
 			t.Errorf("Expected default debug to be false, but got true")
 		}
@@ -349,6 +353,103 @@ upload_path = "../../grims"
 
 		if config.UploadPath != expectedUploadPath {
 			t.Errorf("Expected upload_path to be %s, but got %s", expectedUploadPath, config.UploadPath)
+		}
+	})
+
+	t.Run("load redirect_url from config file", func(t *testing.T) {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+		tempFile, err := os.CreateTemp("", "config-redirect-*.toml")
+		if err != nil {
+			t.Fatalf("Error creating temporary file: %v", err)
+		}
+		defer os.Remove(tempFile.Name())
+
+		configContent := `
+bind = "localhost:8080"
+redirect_url = "https://cdn.example.com"
+`
+		if _, err := tempFile.Write([]byte(configContent)); err != nil {
+			t.Fatalf("Error writing to temporary file: %v", err)
+		}
+
+		config := loadConfig(tempFile.Name())
+
+		if config.RedirectURL != "https://cdn.example.com" {
+			t.Errorf("Expected redirect_url to be https://cdn.example.com, but got %s", config.RedirectURL)
+		}
+
+		if config.Bind != "localhost:8080" {
+			t.Errorf("Expected bind to be localhost:8080, but got %s", config.Bind)
+		}
+	})
+
+	t.Run("redirect_url defaults to empty when not in config", func(t *testing.T) {
+		tempFile, err := os.CreateTemp("", "config-no-redirect-*.toml")
+		if err != nil {
+			t.Fatalf("Error creating temporary file: %v", err)
+		}
+		defer os.Remove(tempFile.Name())
+
+		configContent := `bind = "localhost:8080"`
+		if _, err := tempFile.Write([]byte(configContent)); err != nil {
+			t.Fatalf("Error writing to temporary file: %v", err)
+		}
+
+		config := loadConfig(tempFile.Name())
+
+		if config.RedirectURL != "" {
+			t.Errorf("Expected redirect_url to be empty (default), but got %s", config.RedirectURL)
+		}
+	})
+
+	t.Run("cli flag redirect-url overrides config file", func(t *testing.T) {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+		tempFile, err := os.CreateTemp("", "config-redirect-override-*.toml")
+		if err != nil {
+			t.Fatalf("Error creating temporary file: %v", err)
+		}
+		defer os.Remove(tempFile.Name())
+
+		configContent := `
+bind = "localhost:9000"
+redirect_url = "https://old.example.com"
+`
+		if _, err := tempFile.Write([]byte(configContent)); err != nil {
+			t.Fatalf("Error writing to temporary file: %v", err)
+		}
+
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+		os.Args = []string{"cmd", "--config", tempFile.Name(), "--redirect-url", "https://new.example.com"}
+
+		config := GenerateConfig()
+
+		if config.RedirectURL != "https://new.example.com" {
+			t.Errorf("Expected redirect_url from CLI flag to be https://new.example.com, but got %s", config.RedirectURL)
+		}
+
+		if config.Bind != "localhost:9000" {
+			t.Errorf("Expected bind from config file to be localhost:9000, but got %s", config.Bind)
+		}
+	})
+
+	t.Run("cli flag redirect-url without config file", func(t *testing.T) {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+		os.Args = []string{"cmd", "--redirect-url", "https://mycdn.example.com"}
+
+		config := GenerateConfig()
+
+		if config.RedirectURL != "https://mycdn.example.com" {
+			t.Errorf("Expected redirect_url from CLI flag to be https://mycdn.example.com, but got %s", config.RedirectURL)
+		}
+
+		// Should still have default values for other fields
+		if config.Bind != "0.0.0.0:3000" {
+			t.Errorf("Expected default bind, but got %s", config.Bind)
 		}
 	})
 }

--- a/main.go
+++ b/main.go
@@ -11,10 +11,11 @@ import (
 )
 
 type Config struct {
-	Bind       string `toml:"bind"`
-	Debug      bool   `toml:"debug"`
-	ServePath  string `toml:"serve_path"`
-	UploadPath string `toml:"upload_path"`
+	Bind        string `toml:"bind"`
+	Debug       bool   `toml:"debug"`
+	RedirectURL string `toml:"redirect_url"`
+	ServePath   string `toml:"serve_path"`
+	UploadPath  string `toml:"upload_path"`
 }
 
 var config Config


### PR DESCRIPTION
Rather than fronting grombley with basic auth some users may wish to run the upload server on a non-public url.